### PR TITLE
Make proxy follow redirects server-side instead of passing to the browser

### DIFF
--- a/html/webapp/functions/programs.js
+++ b/html/webapp/functions/programs.js
@@ -41,7 +41,7 @@ export async function onRequest(context) {
             request.headers.set("Origin", new URL(targetUrl).origin);
             
             // Perform request to destination URL.
-            let response = await fetch(request);
+            let response = await fetch(request, { redirect: 'follow' });
             
             // Recreate the response so you can modify the headers
             response = new Response(response.body, response);


### PR DESCRIPTION
Fixes #2

Changes fetch(request) to `fetch(request, { redirect: 'follow' })` so the Cloudflare Worker follows redirects server-side rather than passing them through to the browser.

See the linked issue for full diagnosis, a failing example, a working example, and a discussion of the bandwidth trade-off. 

Tested locally using Wrangler — before the fix the proxy returns a 302 to the browser; after the fix it returns a 200 with the proxy's own CORS headers applied.