### PR TITLE
Fix file open (ADD) button not opening file picker in Safari

### DIFF
--- a/core/src/main/java/emu/joric/HomeScreen.java
+++ b/core/src/main/java/emu/joric/HomeScreen.java
@@ -829,12 +829,20 @@ public class HomeScreen extends InputAdapter implements Screen {
     }
     
     private void importProgram() {
-        Gdx.app.postRunnable(new Runnable() {
-            @Override
-            public void run() {
-                importProgramUsingOpenFileDialog();
-            }
-        });
+        // Invoked synchronously from the click handler so that Safari's
+        // "user activation" token is still valid when
+        // GwtDialogHandler.openFileDialog eventually calls .click() on the
+        // <input type="file">. Safari only allows the native file picker to
+        // open if .click() runs in the same synchronous event stack as the
+        // original user-gesture event; any intervening async step (e.g.
+        // Gdx.app.postRunnable, which defers to the next frame) causes
+        // Safari to revoke the token and silently refuse the picker.
+        //
+        // Each platform's DialogHandler openFileDialog implementation
+        // handles its own thread affinity internally (Desktop wraps in
+        // Gdx.app.postRunnable for Swing, Android uses runOnUiThread), so
+        // calling synchronously should be safe on all platforms.
+        importProgramUsingOpenFileDialog();
     }
     
     private void importProgramUsingOpenFileDialog() {


### PR DESCRIPTION
Safari enforces the "user activation" rule for opening native file pickers more strictly than Chrome: `.click()` on an
`<input type="file">` must run in the same synchronous event stack as the user-gesture event. `HomeScreen.importProgram()` was wrapping the call in `Gdx.app.postRunnable(...)`, which defers by one frame - long enough for Safari to revoke the token and silently refuse the picker.

Calling synchronously is safe on all three platforms because each `DialogHandler.openFileDialog` implementation handles its own thread affinity internally (Desktop wraps for Swing, Android uses `runOnUiThread`, GWT runs synchronously).

### Testing

- Safari 18 on macOS - ADD button now opens the picker.
- Chrome on macOS - still works, no regression.
- Desktop / Android - not tested but should be no behavioural change (each platform's dialog handler retains its own thread wrapping).