### PR TITLE
Fix DC-offset audio glitches in browser hosted emulator

### DIFF
--- a/html/src/main/java/emu/joric/gwt/GwtAYPSG.java
+++ b/html/src/main/java/emu/joric/gwt/GwtAYPSG.java
@@ -83,6 +83,15 @@ public class GwtAYPSG implements AYPSG {
     private int sampleBufferOffset = 0;
     private double cyclesToNextSample;
     private SharedQueue sampleSharedQueue;
+
+    // One-pole DC-blocker state and coefficient used to model the AC coupling capacitor
+    // on Oric audio output to remove the DC offset that the audio chip's emulated unipolar
+    // signal would otherwise carry into the AudioWorklet output.
+    // R = 0.995 gives a -3 dB corner at ~17.5 Hz @ 22050 Hz sample rate, which should be
+    // below any expected normally audible Oric content.
+    private static final float DC_BLOCKER_R = 0.995f;
+    private float dcBlockerX1;
+    private float dcBlockerY1;
     
     // TODO: Remove these after debugging timing issue.
     private long cycleCount;
@@ -156,6 +165,9 @@ public class GwtAYPSG implements AYPSG {
         addressLatch = 0;
 
         cyclesToNextSample = CYCLES_PER_SAMPLE;
+
+        dcBlockerX1 = 0f;
+        dcBlockerY1 = 0f;
     }
 
     /**
@@ -538,12 +550,25 @@ public class GwtAYPSG implements AYPSG {
             }
         }
 
-        int sample = (((((VOLUME_LEVELS[volumeA] * cnt[A]) >> 13) + 
-                        ((VOLUME_LEVELS[volumeB] * cnt[B]) >> 13) + 
-                        ((VOLUME_LEVELS[volumeC] * cnt[C]) >> 13)) & 0x7FFF));
+        int sample = Math.min(((VOLUME_LEVELS[volumeA] * cnt[A]) >> 13) +
+                      ((VOLUME_LEVELS[volumeB] * cnt[B]) >> 13) +
+                      ((VOLUME_LEVELS[volumeC] * cnt[C]) >> 13), 0x7FFF);
 
-        // Conversion to -1.0 to 1.0, which is what the AudioWorkletProcessor needs.
-        sampleBuffer.set(sampleBufferOffset, ((sample - 16384.0f) / 16384.0f));
+        // Use a simple DC blocker to convert to -1.0 to 1.0, which is what the
+        // AudioWorkletProcessor needs. The output clamp is folded into the same
+        // expression as the filter, so on the rare transient that hits the rail
+        // (e.g. a register write flipping the chip from full silence to full output
+        // in one sample), the clamped value is what gets fed back into the filter
+        // state. (Clamping the filter state is arguably less mathematically accurate,
+        // because the clamping behaviour is non-linear. But this approach brings us
+        // out of the clipping state and into more normal behaviour faster, and is
+        // likely a closer approximation of the original hardware circuit bahaviour.)
+        float x = sample / 16384.0f;
+        float y = Math.max(-1f, Math.min(1f,
+                        x - dcBlockerX1 + DC_BLOCKER_R * dcBlockerY1));
+        dcBlockerX1 = x;
+        dcBlockerY1 = y;
+        sampleBuffer.set(sampleBufferOffset, y);
 
         // Increment total sample count, so that we can keep in sync with cycle count.
         sampleCount++;


### PR DESCRIPTION
## Fix for audio glitches in the browser-hosted emulator 

### 1. DC offset on the AudioWorklet output

The emulated AY-3-8912 produces a unipolar signal: each of the three channels contributes a non-negative value, with a DC offset that varies over time based on overall volume. So silence is 0, and a full volume signal will average over time around the 16384 mid-point. To convert to the -1 to +1 range the AudioWorkletProcessor the original conversion subtracted a fixed value `16384.0f` to centre the signal to 0, which would correct the DC offset when the a signal is being played at max volume but meant that silence was effectively being converted to -1. This leads to loud clicks when the audio signal is switched on/off (e.g. emulator paused or restarted, or sound on/off icon clicked on) and could possibly in some cases lead to excess speaker coil load depending on the physical output chain.

This proposed fix replaces the static subtraction with a one-pole DC blocker (`y[n] = x[n] - x[n-1] + R·y[n-1]`, `R = 0.995`). At the 22050 Hz sample rate used this gives a -3 dB corner around 17.5 Hz which should be below any audible content the Oric would normally produce, but high enough to effectively remove the DC offset drift this bug is about.

### 2. Wrap-on-overflow in the channel sum

I'm not totally sure if this condition would ever be hit (I don't know the emulator well enough), but the three output channels were summed and then masked with `& 0x7FFF`. If the sum ever exceeded 15 bits the mask would effectively wrap the value, producing a sharp discontinuity in the sample stream and an audible click. Replaced with `Math.min(..., 0x7FFF)` so loud sums clamp at the rail instead of wrapping.

### Implementation notes

- The output clamp to ±1.0 is folded into the same expression as the DC blocker, so a rail-hit (e.g. silence-to-full-output in one sample) feeds the *clamped* value back into the filter state. This is non-linear, but bounds the filter state, and I think probably more closely matches the saturating behaviour of a real AC coupling cap, and recovers from clipping faster than feeding the raw overshoot back into the filter would. 
- Filter state is reset alongside the existing reset path.
- No changes outside `GwtAYPSG`; desktop / Android paths are unaffected.

### Testing

Tested locally in Safari and Chrome and the previously very audible clicks/thumps on transitions are gone. No audible regressions on content that I could hear in the programs I tested with, but it would be great to get a quick double check by whoever reviews this PR with programs they are familiar with.