### PR TITLE
Inject synthetic keyup events to recover from macOS swallowing them while a Meta key is held

### DIFF
--- a/html/src/main/java/emu/joric/gwt/GwtKeyboardMatrix.java
+++ b/html/src/main/java/emu/joric/gwt/GwtKeyboardMatrix.java
@@ -20,6 +20,12 @@ public class GwtKeyboardMatrix extends KeyboardMatrix {
      */
     public GwtKeyboardMatrix() {
         keyMatrix = createKeyMatrixArray();
+        // Install a DOM-level Meta-key watcher. See
+        // registerMetaKeyWatcher's Javadoc for the macOS keyup-
+        // suppression behaviour it works around. Only the UI-thread
+        // constructor calls this - the web-worker constructor below
+        // has no DOM to listen to.
+        registerMetaKeyWatcher();
     }
     
     /**
@@ -44,7 +50,85 @@ public class GwtKeyboardMatrix extends KeyboardMatrix {
         var keyMatrix = this.@emu.joric.gwt.GwtKeyboardMatrix::keyMatrix;
         return keyMatrix.buffer;
     }-*/;
-    
+
+    /**
+     * Installs DOM-level keydown/keyup listeners that synthesise
+     * keyup events for non-Meta keys whose natural keyup was
+     * swallowed by macOS while a Meta key was held.
+     *
+     * macOS suppresses keyUp events for non-modifier keys whose keyUp
+     * would occur while a Meta (CMD) key is held. THis is an OS-level
+     * behaviour inherited by Chrome, Safari and Firefox (open
+     * browser bugs dating back to 2011, still unresolved as of
+     * writing). The consequence in libGDX's GWT backend
+     * (DefaultGwtInput.java) is that its internal pressedKeys[]
+     * array gets stuck `true` for the un-released key. Typical
+     * symptom for Oric input behaviour: after CMD+X, X stays pressed,
+     * generating auto-repeat X inputs until the next plain X press.
+     *
+     * The workaround is to listen at the DOM level (capture phase, so 
+     * we run before libGDX's own document-level bubble-phase listener).
+     * On every keydown/keyup, observe event.metaKey to track Meta
+     * pressed/released. On the released transition, dispatch a
+     * synthetic keyup for every non-Meta key whose keydown we saw
+     * without a subsequent keyup. The synthetic events flow through
+     * libGDX's normal keyup handler, which clears its internal
+     * pressedKeys[] state. (Note that in the case where a non-Meta
+     * key is still held down when Meta is released, MacOS appears
+     * to generate suitable key events so they effectively appear as
+     * new key presses without the Meta modifier.)
+     */
+    private native void registerMetaKeyWatcher()/*-{
+        var metaPressed = false;
+        // DOM keyCodes of non-Meta keys we've seen keydown but not
+        // (yet) keyup for. Excludes the Meta key DOM codes (91, 92,
+        // 93 - values vary slightly across browsers and key
+        // locations - plus 224 for some Firefox variants).
+        var trackedKeys = {};
+
+        var update = function(e) {
+            var wasMetaPressed = metaPressed;
+            var isMetaPressed = !!e.metaKey;
+            metaPressed = isMetaPressed;
+            var code = e.keyCode;
+
+            // Track DOM press/release for non-Meta keys.
+            if (code !== 91 && code !== 92 && code !== 93 && code !== 224) {
+                if (e.type === 'keydown') {
+                    trackedKeys[code] = true;
+                } else if (e.type === 'keyup') {
+                    delete trackedKeys[code];
+                }
+            }
+
+            // Meta key just released. Synthesise keyup events for any
+            // still-tracked keys so libGDX's internal pressedKeys[]
+            // gate is cleared. Snapshot before iterating because the
+            // synthetic dispatch re-enters this handler (the keyup
+            // branch above) and would otherwise mutate trackedKeys
+            // mid-iteration.
+            if (wasMetaPressed && !isMetaPressed) {
+                var snapshot = [];
+                for (var k in trackedKeys) snapshot.push(k);
+                trackedKeys = {};
+                for (var i = 0; i < snapshot.length; i++) {
+                    var kc = +snapshot[i];
+                    // keyCode and which aren't part of KeyboardEvent's init dict,
+                    // so passing them to the constructor has no effect. Override
+                    // via Object.defineProperty after construction. libGDX's
+                    // keyForCode reads keyCode via NativeEvent.getKeyCode().
+                    var ke = new KeyboardEvent('keyup', { bubbles: true, cancelable: true });
+                    Object.defineProperty(ke, 'keyCode', { value: kc });
+                    Object.defineProperty(ke, 'which',   { value: kc });
+                    $doc.dispatchEvent(ke);
+                }
+            }
+        };
+
+        $doc.addEventListener('keydown', update, true);
+        $doc.addEventListener('keyup',   update, true);
+    }-*/;
+
     @Override
     public int getKeyMatrixRow(int row) {
         return keyMatrix.get(row);


### PR DESCRIPTION
This PR addresses macOS swallowing keyup events while a Meta (CMD) key is held. 

## Problem

On macOS, the OS swallows keyup events for non-modifier keys whose keyup would land while a Meta (CMD) key is held. This is a long-standing macOS behaviour is inherited by Safari, Chrome, and Firefox. This results in the key becoming "stuck" down, until it is next pressed and released. So for example, if the user types CMD-X into the Oric BASIC command line, then X becomes stuck held down, generating auto-repeat X characters indefinitely until the user next presses and releases X. (And because of Oric's keyboard scanning behaviour, pressing any other key does not cancel the auto-repeat / stuck key. You have to press the X itself.)

## Fix

Added  a DOM-level keydown/keyup listener via JSNI to `GwtKeyboardMatrix`. It tracks which non-Meta keycodes have received a keydown but not yet a keyup. On the transition from CMD-held → CMD-released, it dispatches synthetic DOM keyup events for those tracked keys. The synthetic events flow through libGDX's normal listener path (it doesn't know they're synthetic) and clear the stuck `pressedKeys[]` entries.

## Scope

- GWT/web only. The lwjgl3 desktop backend already correctly translates `GLFW_KEY_LEFT/RIGHT_SUPER` to `Keys.SYM`, so I think it doesn't have the same `pressedKeys[]` gate problem. But note I've not been able to test this first hand because the desktop version doesn't currently run for me on my Mac. (I may investigate this problem another time.)
- Listens with `useCapture=true` so it runs before libGDX's own listener (which uses `useCapture=false`).

## Testing

I've confirmed the fix behaves as expected for me using both Safari and Chrome on macOS. I haven't been able to verity Windows and Linux behaves as expected as I don't have easy access to a Windows or Linux desktops. I think the code is pretty safe but it would be good to verify on at least one other OS to be sure before merging.
