### PR TITLE
Fix Swing dialog deadlock on macOS desktop build

### DIFF
--- a/lwjgl3/src/main/java/emu/joric/lwjgl3/DesktopDialogHandler.java
+++ b/lwjgl3/src/main/java/emu/joric/lwjgl3/DesktopDialogHandler.java
@@ -16,6 +16,7 @@ import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.filechooser.FileSystemView;
 
@@ -104,17 +105,30 @@ public class DesktopDialogHandler implements DialogHandler {
     
     @Override
     public void confirm(final String message, final ConfirmResponseHandler responseHandler) {
-        Gdx.app.postRunnable(new Runnable() {
+        // The Swing dialog must run on the AWT Event Dispatch Thread (EDT),
+        // not on the libGDX main thread. The Swing API normally expects its 
+        // components to be accessed from the AWT EDT. On macOS the libGDX main 
+        // thread is also the AppKit main thread (because of -XstartOnFirstThread),
+        // so if we made Swing dialog calls from there they would deadlock against 
+        // the EDT. So we dispatch via SwingUtilities.invokeLater, and post the 
+        // response back to the libGDX main thread so the response handler interacts 
+        // with libGDX state safely.
+        SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
                 dialogOpen = true;
-                int output = JOptionPane.showConfirmDialog(null, message, "Please confirm", JOptionPane.YES_NO_OPTION);
+                final int output = JOptionPane.showConfirmDialog(null, message, "Please confirm", JOptionPane.YES_NO_OPTION);
                 dialogOpen = false;
-                if (output != 0) {
-                    responseHandler.no();
-                } else {
-                    responseHandler.yes();
-                }
+                Gdx.app.postRunnable(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (output != 0) {
+                            responseHandler.no();
+                        } else {
+                            responseHandler.yes();
+                        }
+                    }
+                });
             }
         });
     }
@@ -122,7 +136,9 @@ public class DesktopDialogHandler implements DialogHandler {
     @Override
     public void openFileDialog(String title, final String startPath,
             final OpenFileResponseHandler openFileResponseHandler) {
-        Gdx.app.postRunnable(new Runnable() {
+        // See confirm() for why the Swing dialog is dispatched onto the EDT
+        // and the response is posted back to the libGDX main thread.
+        SwingUtilities.invokeLater(new Runnable() {
 
             @Override
             public void run() {
@@ -138,14 +154,21 @@ public class DesktopDialogHandler implements DialogHandler {
                 jfc.addChoosableFileFilter(filter);
 
                 dialogOpen = true;
-                int returnValue = jfc.showOpenDialog(null);
+                final int returnValue = jfc.showOpenDialog(null);
+                final String selectedPath = (returnValue == JFileChooser.APPROVE_OPTION)
+                        ? jfc.getSelectedFile().getPath() : null;
                 dialogOpen = false;
-                if (returnValue == JFileChooser.APPROVE_OPTION) {
-                    System.out.println(jfc.getSelectedFile().getPath());
-                    openFileResponseHandler.openFileResult(true, jfc.getSelectedFile().getPath(), null);
-                } else {
-                    openFileResponseHandler.openFileResult(false, null, null);
-                }
+                Gdx.app.postRunnable(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (selectedPath != null) {
+                            System.out.println(selectedPath);
+                            openFileResponseHandler.openFileResult(true, selectedPath, null);
+                        } else {
+                            openFileResponseHandler.openFileResult(false, null, null);
+                        }
+                    }
+                });
             }
         });
     }
@@ -153,105 +176,133 @@ public class DesktopDialogHandler implements DialogHandler {
     @Override
     public void promptForTextInput(final String message, final String initialValue,
             final TextInputResponseHandler textInputResponseHandler) {
-        Gdx.app.postRunnable(new Runnable() {
+        // See confirm() for why the Swing dialog is dispatched onto the EDT
+        // and the response is posted back to the libGDX main thread.
+        SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
                 dialogOpen = true;
-                String text = (String) JOptionPane.showInputDialog(null, message, "Please enter value",
+                final String text = (String) JOptionPane.showInputDialog(null, message, "Please enter value",
                         JOptionPane.INFORMATION_MESSAGE, null, null, initialValue != null ? initialValue : "");
                 dialogOpen = false;
-                
-                if (text != null) {
-                    textInputResponseHandler.inputTextResult(true, text);
-                } else {
-                    textInputResponseHandler.inputTextResult(false, null);
-                }
+                Gdx.app.postRunnable(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (text != null) {
+                            textInputResponseHandler.inputTextResult(true, text);
+                        } else {
+                            textInputResponseHandler.inputTextResult(false, null);
+                        }
+                    }
+                });
             }
         });
     }
     
     @Override
-    public void showAboutDialog(String aboutMessage, TextInputResponseHandler textInputResponseHandler) {
-        dialogOpen = true;
-        
-        JButton spacerButton = new JButton(
-                "                                                                  ");
-        spacerButton.setVisible(false);
-        JButton exportButton = new JButton(getExportIcon());
-        JButton importButton = new JButton(getImportIcon());
-        JButton resetButton = new JButton(getResetIcon());
-        JButton clearButton = new JButton(getClearIcon());
-        JButton okButton = new JButton("OK");
-        //Object[] options = { exportButton, importButton, resetButton, clearButton, spacerButton, okButton };
-        Object[] options = { okButton };
-        
-        final JOptionPane pane = new JOptionPane(
-                aboutMessage, 
-                JOptionPane.INFORMATION_MESSAGE,
-                JOptionPane.DEFAULT_OPTION, 
-                loadIcon("png/joric-64x64.png"),
-                options, okButton);
-        
-        MouseAdapter mouseListener = new MouseAdapter() {
+    public void showAboutDialog(final String aboutMessage, final TextInputResponseHandler textInputResponseHandler) {
+        // See confirm() for why the Swing dialog is dispatched onto the EDT
+        // and the response is posted back to the libGDX main thread. Unlike
+        // the other dialog methods this one wasn't previously wrapped in
+        // Gdx.app.postRunnable, but the cause was the same: it ran on
+        // whatever thread called it, which is the libGDX main thread from
+        // the in-emulator UI.
+        SwingUtilities.invokeLater(new Runnable() {
             @Override
-            public void mouseClicked(MouseEvent e) {
-                JButton button = (JButton)e.getComponent();
-                if (button == exportButton) {
-                    pane.setValue("EXPORT");
-                }
-                else if (button == importButton) {
-                    pane.setValue("IMPORT");
-                }
-                else if (button == resetButton) {
-                    pane.setValue("RESET");
-                }
-                else if (button == clearButton) {
-                    pane.setValue("CLEAR");
-                }
-                else {
-                    pane.setValue("OK");
-                }
+            public void run() {
+                dialogOpen = true;
+
+                JButton spacerButton = new JButton(
+                        "                                                                  ");
+                spacerButton.setVisible(false);
+                final JButton exportButton = new JButton(getExportIcon());
+                final JButton importButton = new JButton(getImportIcon());
+                final JButton resetButton = new JButton(getResetIcon());
+                final JButton clearButton = new JButton(getClearIcon());
+                final JButton okButton = new JButton("OK");
+                //Object[] options = { exportButton, importButton, resetButton, clearButton, spacerButton, okButton };
+                Object[] options = { okButton };
+
+                final JOptionPane pane = new JOptionPane(
+                        aboutMessage,
+                        JOptionPane.INFORMATION_MESSAGE,
+                        JOptionPane.DEFAULT_OPTION,
+                        loadIcon("png/joric-64x64.png"),
+                        options, okButton);
+
+                MouseAdapter mouseListener = new MouseAdapter() {
+                    @Override
+                    public void mouseClicked(MouseEvent e) {
+                        JButton button = (JButton)e.getComponent();
+                        if (button == exportButton) {
+                            pane.setValue("EXPORT");
+                        }
+                        else if (button == importButton) {
+                            pane.setValue("IMPORT");
+                        }
+                        else if (button == resetButton) {
+                            pane.setValue("RESET");
+                        }
+                        else if (button == clearButton) {
+                            pane.setValue("CLEAR");
+                        }
+                        else {
+                            pane.setValue("OK");
+                        }
+                    }
+                };
+
+                exportButton.addMouseListener(mouseListener);
+                importButton.addMouseListener(mouseListener);
+                resetButton.addMouseListener(mouseListener);
+                clearButton.addMouseListener(mouseListener);
+                okButton.addMouseListener(mouseListener);
+
+                pane.setComponentOrientation(JOptionPane.getRootFrame().getComponentOrientation());
+                JDialog dialog = pane.createDialog("About JOric");
+                dialog.setIconImage(loadImage("png/joric-32x32.png"));
+                dialog.show();
+                dialog.dispose();
+
+                final Object paneValue = pane.getValue();
+                dialogOpen = false;
+                Gdx.app.postRunnable(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (paneValue != null) {
+                            textInputResponseHandler.inputTextResult(true, (String)paneValue);
+                        } else {
+                            textInputResponseHandler.inputTextResult(false, null);
+                        }
+                    }
+                });
             }
-        };
-        
-        exportButton.addMouseListener(mouseListener);
-        importButton.addMouseListener(mouseListener);
-        resetButton.addMouseListener(mouseListener);
-        clearButton.addMouseListener(mouseListener);
-        okButton.addMouseListener(mouseListener);
-        
-        pane.setComponentOrientation(JOptionPane.getRootFrame().getComponentOrientation());
-        JDialog dialog = pane.createDialog("About JOric");
-        dialog.setIconImage(loadImage("png/joric-32x32.png"));
-        dialog.show();
-        dialog.dispose();
-        
-        if (pane.getValue() != null) {
-            textInputResponseHandler.inputTextResult(true, (String)pane.getValue());
-        } else {
-            textInputResponseHandler.inputTextResult(false, null);
-        }
-        
-        dialogOpen = false;
+        });
     }
-    
+
     @Override
     public void promptForOption(final String title, final String message, final String[] options,
             final String currentSelection, final TextInputResponseHandler textInputResponseHandler) {
-        Gdx.app.postRunnable(new Runnable() {
+        // See confirm() for why the Swing dialog is dispatched onto the EDT
+        // and the response is posted back to the libGDX main thread.
+        SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
                 dialogOpen = true;
                 String dialogTitle = (title != null && !title.isEmpty()) ? title : "JOric";
-                Object result = JOptionPane.showInputDialog(null, message, dialogTitle,
+                final Object result = JOptionPane.showInputDialog(null, message, dialogTitle,
                         JOptionPane.QUESTION_MESSAGE, null, options, currentSelection);
                 dialogOpen = false;
-
-                if (result != null) {
-                    textInputResponseHandler.inputTextResult(true, result.toString());
-                } else {
-                    textInputResponseHandler.inputTextResult(false, null);
-                }
+                Gdx.app.postRunnable(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (result != null) {
+                            textInputResponseHandler.inputTextResult(true, result.toString());
+                        } else {
+                            textInputResponseHandler.inputTextResult(false, null);
+                        }
+                    }
+                });
             }
         });
     }

--- a/lwjgl3/src/main/java/emu/joric/lwjgl3/DesktopLauncher.java
+++ b/lwjgl3/src/main/java/emu/joric/lwjgl3/DesktopLauncher.java
@@ -14,6 +14,16 @@ public class DesktopLauncher {
     
     public static void main(String[] args) {
         if (StartupHelper.startNewJvmIfRequired()) return; // This handles macOS support and helps on Windows.
+        // Pre-initialize AWT before libGDX claims the main thread. On macOS,
+        // -XstartOnFirstThread gives the main thread to GLFW, but AWT also
+        // requires the main thread to initialise its AppKit backend the
+        // first time it's used. If we let that first use happen later (e.g.
+        // when a JFileChooser is opened by DesktopDialogHandler), AppKit
+        // init hangs forever waiting for a main thread that GLFW now owns.
+        // Calling Toolkit.getDefaultToolkit() here forces AppKit init to
+        // happen while the main thread is still ours, so later AWT calls
+        // from any thread find it already initialised.
+        java.awt.Toolkit.getDefaultToolkit();
         createApplication(convertArgsToMap(args));
     }
 


### PR DESCRIPTION
## Problem

On macOS, clicking any UI button that opens a Swing dialog (File Open, Help / About, Emulator Reset, etc.) hangs JOric with a spinning beach ball that never recovers. The in-emulator curated program list still works because it's rendered by libGDX itself rather than via a Swing dialog.

The root cause is the collision of two macOS-specific main-thread constraints:

1. **GLFW needs the OS main thread.** libGDX's lwjgl3 backend uses GLFW, which on macOS must run its event loop on the OS main thread (thread 0). `StartupHelper.startNewJvmIfRequired` already arranges this by re-launching the child JVM with `-XstartOnFirstThread`, so the libGDX render thread *is* the macOS main thread.
2. **AWT/Swing also needs the OS main thread** for AppKit initialisation and dispatch. Swing modal dialogs normally route their event handling through the AWT Event Dispatch Thread (EDT), which in turn round-trips to the main thread for AppKit work.

These two constraints fight: GLFW ends up owning the main thread, leaving no main thread available for AppKit when a Swing dialog needs it. The existing code dispatches Swing dialogs onto the libGDX render thread via `Gdx.app.postRunnable`, making the dialog call run on the thread AppKit needs to be free. The dialog parks waiting for the EDT to complete its dispatch; the EDT can't complete because it needs the main thread; the main thread is parked waiting for the dialog - which results in a deadlock.

I confirmed this via `jstack` on a hung run: the main thread parked in `Object.wait()` inside `JFileChooser.showOpenDialog` → `WaitDispatchSupport.enter`, with the AWT-EventQueue thread spinning in `sun.lwawt.macosx.LWCToolkit.isApplicationActive` trying to round-trip to the macOS main thread (which was the very thread parked above).

I think this is a macOS-only manifestation. Windows and Linux don't have the same `-XstartOnFirstThread`-style main-thread constraint for either GLFW or AWT. However, I think the existing `Gdx.app.postRunnable` pattern technically also violates the Swing thread-safety contract on those platforms (Swing components are normally only supposed to be accessed from the EDT), but the violation just happens to not deadlock there because there's no contested main thread to serialise on.

## Fix

Two changes, both applied unconditionally on all OSes although the bug only manifests on macOS:

- **`DesktopDialogHandler`**: route the five dialog methods (`confirm`, `openFileDialog`, `promptForTextInput`, `showAboutDialog`, `promptForOption`) through `SwingUtilities.invokeLater` instead of `Gdx.app.postRunnable`. The response handler is then posted back through `Gdx.app.postRunnable` so it returns to the libGDX render thread for any subsequent libGDX-state mutation. This is contract-compliant with Swing's "components are only accessed from the EDT" rule on every OS, not just macOS.

- **`DesktopLauncher`**: pre-initialise AWT via `java.awt.Toolkit.getDefaultToolkit()` after `StartupHelper.startNewJvmIfRequired` returns but before the `Lwjgl3Application` constructor takes over the main thread. Without this, the first Swing call later in the lifecycle would try to initialise AppKit from a non-main thread (the dispatched EDT runnable) and hang. Pre-initialising allows AppKit to initialise on the main thread before libGDX takes it over. This is required for macOS and should be no-op-ish on Windows / Linux (where AWT doesn't have a main-thread requirement).

## Scope

- All five dialog methods migrated to the same pattern.
- The `Toolkit.getDefaultToolkit()` pre-init is a single line in the launcher. Could be platform-gated to macOS only if preferred; I left it un-gated because the cost on other platforms is negligible and thought it better to have a single code path for simplicity.

## Testing

I've confirmed the fix behaves as expected for me using the macOS desktop for `openFileDialog`, `promptForOption`, `showAboutDialog`, and `confirm` dialogs. Before this PR, clicking any of these would beach-ball and never recover. After this PR, all these dialogs open promptly and return the results as expected.

However, I have not tested the `promptForTextInput` dialog because I couldn't see any place in the UI that used it?

I also  haven't been able to verify Windows / Linux (I don't have easy access to either). The pattern change is conservative enough that I'd expect it to work as a no-op behaviour-wise on those platforms - I assume the dialogs were already working there, and `SwingUtilities.invokeLater` is the documented Swing convention. But it would be good to verify on at least one other OS to be sure before merging.

