### PR TITLE
Fix desktop audio rate misalignment and add simple pre-fill & audio timing drift management

### DIFF
--- a/core/src/main/java/emu/joric/JOricRunner.java
+++ b/core/src/main/java/emu/joric/JOricRunner.java
@@ -44,7 +44,18 @@ import emu.joric.ui.MachineInputProcessor;
  */
 public abstract class JOricRunner {
     
-    protected static final int NANOS_PER_FRAME = (1000000000 / MachineType.PAL.getFramesPerSecond());
+    // Derived from the Oric PAL frame structure: 312 scanlines x 64 cycles
+    // per scanline at 1 MHz = 19,968,000 ns per frame (equivalent to
+    // ~50.08 FPS). Computing this from MachineType.PAL.getFramesPerSecond()
+    // would round to 50 FPS exactly, causing the desktop emulator to run
+    // ~0.16% slower than a real PAL Oric. On its own that's a small
+    // accuracy issue, but downstream it would make the audio sample production
+    // rate run 0.16% slower than the audio hardware's consumption rate,
+    // causing the audio buffer to slowly drain and producing periodic
+    // audible glitches as the buffer drops too low. See the drift
+    // management logic in AY38912PSG.writeSample for how the audio side
+    // handles any residual audio timing drift.
+    protected static final int NANOS_PER_FRAME = 19_968_000;
     
     protected MachineScreen machineScreen;
     

--- a/lwjgl3/src/main/java/emu/joric/lwjgl3/AY38912PSG.java
+++ b/lwjgl3/src/main/java/emu/joric/lwjgl3/AY38912PSG.java
@@ -81,6 +81,20 @@ public class AY38912PSG implements AYPSG {
   private int sampleBufferOffset = 0;
   private float cyclesToNextSample;
   private SourceDataLine audioLine;
+
+  // Diagnostic logging in writeSample (drop events, top-up events, periodic
+  // stats) is gated on this flag. Disabled by default so the released build
+  // is silent. Flip to true when investigating audio drift / glitches on a
+  // specific OS or audio backend; the JIT will eliminate the dead branches
+  // when false so there is no runtime cost in the disabled state.
+  private static final boolean DIAGNOSTIC_LOGGING = false;
+
+  // Counters for top-up / drop events in writeSample, used only by the
+  // periodic stats logging gated by DIAGNOSTIC_LOGGING. Increments are also
+  // gated so the fields stay at zero in normal runs.
+  private long flushCount = 0;
+  private long topupCount = 0;
+  private long dropCount = 0;
   
   /**
    * The AY-3-8912 in the Oric gets its data from the 6522 VIA chip.
@@ -133,17 +147,25 @@ public class AY38912PSG implements AYPSG {
     addressLatch = 0;
     
     try {
-      // PCM SIGNED, 16 bit, mono, 2 bytes/frame, little-endian, 50ms buffer size (i.e. delay)
-      int audioBufferSize = ((((SAMPLE_RATE/ 20) * 2) / 10) * 10);
+      // PCM SIGNED, 16 bit, mono, 2 bytes/frame, little-endian, 200ms buffer
+      // size. writeSample manages the buffer usage, targeting 50-60% fullness
+      // which gives us ~120ms latency (same as our web version) with a good
+      // margin for jitter and drift that should minimise audio glitches.
+      int audioBufferSize = ((((SAMPLE_RATE/ 5) * 2) / 10) * 10);
       AudioFormat format = new AudioFormat(SAMPLE_RATE, 16, 1, true, false);
       DataLine.Info info = new DataLine.Info(SourceDataLine.class, format, audioBufferSize);
       audioLine = (SourceDataLine)AudioSystem.getLine(info);
-      audioLine.open();
+      // We need to pass audioBufferSize to open(format, bufferSize) explicitly 
+      // since the value in the DataLine.Info above is only a hint for line 
+      // selection. audioLine.open() with no args uses whatever the
+      // implementation-defined default is (e.g. ~32KB on macOS Java Sound, 
+      // regardless of what we requested in the Info).
+      audioLine.open(format, audioBufferSize);
       audioLine.start();
-      
+
       sampleBuffer = new byte[audioBufferSize / 10];
       sampleBufferOffset = 0;
-      
+
     } catch (LineUnavailableException lue) {
       audioLine = null;
     }
@@ -480,10 +502,68 @@ public class AY38912PSG implements AYPSG {
     sampleBuffer[sampleBufferOffset + 0] = (byte)(sample & 0x00FF);
     sampleBuffer[sampleBufferOffset + 1] = (byte)((sample & 0xFF00) >> 8);
     
-    // If the sample buffer is full, write it out to the audio line.
+    // If the sample buffer is full, flush (write) it out to the audio line
+    // with drift management: drop the flush if the audio line buffer is 
+    // already nearly full (indicating over-production drift), or top up 
+    // with silence to the mid-point if it's nearly empty (under-production
+    // drift, or initial startup pre-fill). Drift in either direction can
+    // arise from small mismatches between the emulator's effective
+    // sample-production rate (based on system clock) and the 
+    // audio hardware's consumption rate (based on audio hardware clock, 
+    // which may or may not be the same as the system clock depending on
+    // the hardware). Drift correction actions can result in audible
+    // clicks/pops if real audio is being played (non-silence), but in 
+    // normal operation of the emulator should occur very infrequently
+    // since the drift rate should be very small and the drift corrections
+    // are applied in relatively large chunks (equivalent to one full 
+    // sampleBuffer at a time) rather than in smaller more frequent increments.
     if ((sampleBufferOffset += 2) == sampleBuffer.length) {
-      audioLine.write(sampleBuffer, 0, sampleBuffer.length);
+      if (DIAGNOSTIC_LOGGING) flushCount++;
+      int audioBufferSize = audioLine.getBufferSize();
+      int flushBytes = sampleBuffer.length;
+      int midPointBytes = audioBufferSize / 2;
+      int topupThresholdBytes = midPointBytes - 2 * flushBytes;
+      int dropThresholdBytes = midPointBytes + 3 * flushBytes;
+      int fullnessBytes = audioBufferSize - audioLine.available();
+
+      if (fullnessBytes > dropThresholdBytes) {
+        // The audioLine buffer is overly full. Drop this flush. Audio line will 
+        // drain by one sampleBuffer's worth of playback before the next flush
+        // occurs, pulling fullness back toward the desired mid-point.
+        if (DIAGNOSTIC_LOGGING) {
+          dropCount++;
+          System.out.println("AY38912PSG: drop flush, fullness="
+                  + (fullnessBytes * 1000L / (SAMPLE_RATE * 2)) + "ms");
+        }
+      } else if (fullnessBytes < topupThresholdBytes) {
+        // The audioLine buffer is overly empty. Top up with silence to bring 
+        // fullness exactly to the mid-point, then perform the flush.
+        int topupBytes = midPointBytes - fullnessBytes;
+        topupBytes = (topupBytes / 2) * 2;   // ensure even (16-bit alignment)
+        if (topupBytes > 0) {
+          byte[] silence = new byte[topupBytes];
+          audioLine.write(silence, 0, silence.length);
+        }
+        audioLine.write(sampleBuffer, 0, sampleBuffer.length);
+        if (DIAGNOSTIC_LOGGING) {
+          topupCount++;
+          System.out.println("AY38912PSG: top-up flush, fullness="
+                  + (fullnessBytes * 1000L / (SAMPLE_RATE * 2)) + "ms, topup="
+                  + (topupBytes * 1000L / (SAMPLE_RATE * 2)) + "ms");
+        }
+      } else {
+        // Normal flush.
+        audioLine.write(sampleBuffer, 0, sampleBuffer.length);
+      }
       sampleBufferOffset = 0;
+
+      // Periodic stats every 500 flushes (~10s at 20ms/flush).
+      if (DIAGNOSTIC_LOGGING && (flushCount % 500) == 0) {
+        int currentFullnessBytes = audioBufferSize - audioLine.available();
+        System.out.println("AY38912PSG: stats, flushes=" + flushCount
+                + ", top-ups=" + topupCount + ", drops=" + dropCount
+                + ", currentFullness=" + (currentFullnessBytes * 1000L / (SAMPLE_RATE * 2)) + "ms");
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

The desktop emulator sound output was suffering from very frequent glitches (at least on macOS) - stuttering, clicks and pops.

The desktop emulator currently clocks each frame at exactly 50 FPS (`NANOS_PER_FRAME = 20_000_000` ns, derived implicitly from `MachineType.PAL.getFramesPerSecond()` rounding to `50`). But I think a real PAL Oric ran 312 scanlines × 64 cycles per scanline at 1 MHz = 19,968 cycles per frame (~50.08 FPS). On its own that's only a ~0.16% accuracy issue, but it makes the emulator's audio sample-production rate (driven by the system clock and `NANOS_PER_FRAME`) run slower than the audio hardware's consumption rate (driven by the desktop host's audio hardware clock). The result is that the audio buffer frequently runs dry.

In addition, the current code doesn't pre-fill the audio buffer at startup, which means jitter in the audio consumer pipeline or in the emulator audio sample production can easily lead to the audio buffer becoming dry for fractions of a second.

On macOS, when combined with the jitter of Java Sound's integration with the Core Audio pipeline, these issues produce audible glitches several times per second during gameplay. (It is possible that other OS audio pipelines are more forgiving - I don't currently have access to Windows or Linux desktops, so don't know for sure. But the underlying rate mismatch still applies so there will still be a shortfall of a small number of audio samples per frame.)

Finally, on some desktop environments the system clock and the audio clock are not tightly coupled and depend on the specific audio hardware being used. So while adjusting `NANOS_PER_FRAME` can make them theoretically the same, in reality they can still drift very slowly relative to each other. Even on a system with zero jitter, this slow drift can lead to the `audioLine` buffer running dry or overrunning if the emulator is running for a long time, again leading to audio glitches.

## Fix

Two changes:

- **`JOricRunner`**: replaced the implicit `NANOS_PER_FRAME` derivation with `protected static final int NANOS_PER_FRAME = 19_968_000;`, derived directly from the Oric PAL frame structure (312 scanlines × 64 cycles per scanline × 1000 ns). 

- **`lwjgl3/AY38912PSG`**: switched to using an explicit `audioLine` buffer size, with simple pre-fill and drift management that roughly targets maintaining ~120ms of audio in the `audioLine` buffer. The audio latency should be comparable to the web version, and be enough to eliminate jitter issues during normal operation. If the buffer fullness is significantly below target then silence is written to top up the buffer. If the buffer is significantly over target then the next chunk of samples is dropped. With the `NANOS_PER_FRAME` cycle-rate fix in place these paths fire essentially only at startup (one top-up does the initial pre-fill) and then sit idle - they act as a safety net for any residual drift of real audio hardware sample rate timing not being perfectly aligned with the system clock.

## Scope

- The audio problems being targeted by this PR are specifically a desktop issue. However, the `NANOS_PER_FRAME` cycle-rate fix lives in shared code (`JOricRunner`), so it's inherited by the web and Android platforms too. For the web path, the constant doesn't appear to be used by the active emulation loop in `JOricWebWorker` (which instead drives cycle execution based on the audio queue consumption rate when sound is on, and based on animation-frame timestamps when sound is off), so there should be no observable change. For Android, the frame rate moves from 50 FPS to ~50.08 FPS, which results in a ~0.16% increase in audio sample production rate. But from what I can see, this is small compared to the existing producer/consumer rate mismatch on Android (which appears to be absorbed today by `AudioTrack.write()` blocking when the buffer is full), and I'd expect no new audio issues from it. But see notes on testing below.
- The buffer management / drift-correction changes are confined to `lwjgl3/AY38912PSG` so the web and Android audio paths are unaffected.
- Diagnostic logging in the drift-correction paths is gated on a `DIAGNOSTIC_LOGGING` static-final boolean (default `false`). The JIT compiler should eliminate the dead branches when disabled, so there's no runtime cost. Flip to `true` if investigating audio behaviour on a specific OS or audio backend.

## Testing

I've confirmed the fix behaves as expected for me on macOS. The drift with the new `NANOS_PER_FRAME` is low enough that an hour-long emulator session doesn't hit the drift management paths (apart from the initial pre-fill at start). I've also tested with artificially small and large `NANOS_PER_FRAME` in order to force the drift management paths to be exercised regularly and they behave as expected.

I've also verified the `NANOS_PER_FRAME` change did not have any perceivable impact on web.

But I don't have access to Android, so have not been able to confirm the `NANOS_PER_FRAME` change has no perceivable impact on Android. (See code reading analysis above which makes me think it should be ok.)

I also don't have easy access to Windows or Linux desktops, so wasn't able to verify the fix works as well on those as it does on macOS (or verify whether the old `NANOS_PER_FRAME` value resulted in audible artefacts on those platforms or whether their audio pipelines are in some way inherently less prone than macOS to the audio glitches). It would be good to verify the PR has no negative impact on at least one other OS before merging.