### PR TITLE
Fix envelope shape decoding for hold shapes 11, 13 and 15

### DIFF
--- a/html/src/main/java/emu/joric/gwt/GwtAYPSG.java
+++ b/html/src/main/java/emu/joric/gwt/GwtAYPSG.java
@@ -400,9 +400,6 @@ public class GwtAYPSG implements AYPSG {
             } else {
                 hold = value & 0x01;
                 alternate = value & 0x02;
-                if (hold != 0) {
-                    attack = alternate;
-                }
             }
             count[ENVELOPE] = period[ENVELOPE];
             countEnv = 0x0f;


### PR DESCRIPTION
## Context

Third in the series of AY-3-8912 sound emulation improvements, web version first as before. The WIP deployment with the whole series applied is available here if you want to hear the overall impact: https://joric-wip.pages.dev

## Problem

Three of the envelope shapes - 11, 13 and 15, the "continue and hold" shapes that ramp once and then hold at a fixed level - decode incorrectly, so they play the wrong ramp and hold at the wrong volume.

Two of these are reachable from Oric BASIC via the PLAY command's envelope parameter, which maps to the shape register through a ROM table: PLAY envelope mode 7 selects shape 13, and mode 5 selects shape 11. (I don't think shape 15 is reachable from BASIC - see Testing.)

Two examples to reproduce to hear:
- `PLAY 0,0,0,0:WAIT 100:SOUND 1,100,0 : PLAY 1,0,7,2000` - shape 13, which should ramp up and hold at maximum. On the current web version it instead starts at maximum and fades to silence.
- `PLAY 0,0,0,0:WAIT 100:SOUND 1,100,0 : PLAY 1,0,5,2000` - shape 11, which should decay once and then hold at maximum. On the current web version it plays an erratic ramp and holds below maximum (at level 13 instead of 15).

The cause is in the envelope shape register (R13) write handler. For the hold shapes it stores the Alternate bit as its raw value (0 or 2) and then also assigns that into the attack state, which both controls the ramp direction and feeds the held-level calculation - so the held volume comes out corrupted. 

## Fix

The per-sample envelope logic already implemented the correct hold behaviour (hold the last count, or flip to the initial count when the Alternate bit is set), so we just needed to remove the erroneous assignment to the attack state from the R13 handler. The shapes then decode correctly: shape 13 ramps up and holds at maximum, shape 11 decays once and holds at maximum, and shape 15 ramps up and holds at silence.

## Scope

Web platform only - one file (GwtAYPSG), a three-line deletion. No changes to core or the other platforms. Only shapes 11, 13 and 15 change behaviour; all other envelope shapes are unaffected.

## Testing

Tested on macOS in Chrome. Confirmed `PLAY 1,0,7,2000` (shape 13) now ramps up and holds at maximum instead of fading to silence, and `PLAY 1,0,5,2000` (shape 11) now decays cleanly and holds at maximum instead of the erratic, below-maximum behaviour. I don't think shape 15 is reachable from Oric BASIC (the ROM's PLAY table has no entry that maps to it), so I could not exercise it from BASIC, but it goes through the identical corrected code path as shapes 11 and 13, so I would expect any games that make use of it to benefit from this fix.