### PR TITLE
Fix period register writes disturbing the tone, noise and envelope counters

### DIFF
--- a/html/src/main/java/emu/joric/gwt/GwtAYPSG.java
+++ b/html/src/main/java/emu/joric/gwt/GwtAYPSG.java
@@ -340,7 +340,12 @@ public class GwtAYPSG implements AYPSG {
             int val = (((registers[(address << 1) + 1] & 0x0f) << 8) | registers[address << 1]) * updateStep;
             int last = period[address];
             period[address] = val = ((val < 0x8000) ? 0x8000 : val);
-            int newCount = count[address] - (val - last);
+            // Adjust the time remaining to the next flip-flop toggle so that the
+            // time already elapsed since the last toggle is preserved, i.e. the
+            // period write moves only the target, as on the real chip. If the
+            // elapsed time already exceeds the new period, the clamp below makes
+            // the overdue toggle happen straight away.
+            int newCount = count[address] + (val - last);
             count[address] = newCount < 1 ? 1 : newCount;
             break;
         }
@@ -351,7 +356,7 @@ public class GwtAYPSG implements AYPSG {
             val *= 2;
             int last = period[NOISE];
             period[NOISE] = val = val == 0 ? updateStep : val;
-            int newCount = count[NOISE] - (val - last);
+            int newCount = count[NOISE] + (val - last);
             count[NOISE] = newCount < 1 ? 1 : newCount;
             break;
         }
@@ -386,7 +391,7 @@ public class GwtAYPSG implements AYPSG {
             int val = (((registers[0x0C] << 8) | registers[0x0B]) * updateStep) << 1;
             int last = period[ENVELOPE];
             period[ENVELOPE] = val;
-            int newCount = count[ENVELOPE] - (val - last);
+            int newCount = count[ENVELOPE] + (val - last);
             count[ENVELOPE] = newCount < 1 ? 1 : newCount;
             break;
         }


### PR DESCRIPTION
## Context

Fourth in the series of AY-3-8912 sound emulation improvements, web version first as before. The WIP deployment with the whole series applied is available here if you want to hear the overall impact: https://joric-wip.pages.dev

## Problem

When a program changes a tone, noise or envelope period while sound is playing, the emulation can create spurious transients, because writing the period register disturbs the running counters. This adds a buzzy texture to anything that rewrites period registers rapidly - pitch slides, vibrato, and alternating tones.

It is subtle in many cases, but a loop that alternates between two well-separated tones makes it clearly audible if you listen for the buzzy texture (a fizz which is higher pitched than either of the tones themselves). For example:

`10 SOUND 1,100,15:SOUND 1,400,15:GOTO 10`

On the current web version this has a distinct buzz to it; with the fix it is noticeably cleaner.

The cause: the tone (R0-R5), noise (R6) and envelope (R11/R12) period handlers adjust the running countdown to the next flip-flop toggle when the period changes, so that the time already elapsed since the last toggle is preserved (which is what the real chip does - a period write changes only the value the counter is compared against, not the counter itself). The counters here count down, so preserving the elapsed time means moving the remaining count by the same amount as the period change. The sign of that adjustment was inverted: it subtracted the change instead of adding it. As a result every period write displaced the next toggle by twice the period change, in the wrong direction - a period increase could push the remaining count below the minimum and force an immediate spurious toggle (the click), and a period decrease stalled the next toggle.

## Fix

Flip the sign of the count adjustment in each of the three period handlers, so the elapsed time is correctly preserved across a period write. Steady tones are unaffected - the adjustment only happens at the moment of a period write, and the counter reloads from the new period at each toggle as before.

## Scope

Web platform only - one file (GwtAYPSG). No changes to core or the other platforms. Only the behaviour at the moment of a period-register write changes; steady-state tone, noise and envelope generation is identical.

## Testing

Tested on macOS in Chrome, using a local A/B comparison. Confirmed `10 SOUND 1,100,15:SOUND 1,400,15:GOTO 10` is audibly cleaner with the fix - the pre-fix version has an extra buzz from the spurious transients on each period write. The difference is subtle on most material, but clearer in other scenarios.