### PR TITLE
Fix noise period 0 running at twice the speed of period 1

### DIFF
--- a/html/src/main/java/emu/joric/gwt/GwtAYPSG.java
+++ b/html/src/main/java/emu/joric/gwt/GwtAYPSG.java
@@ -340,7 +340,12 @@ public class GwtAYPSG implements AYPSG {
             int val = (((registers[(address << 1) + 1] & 0x0f) << 8) | registers[address << 1]) * updateStep;
             int last = period[address];
             period[address] = val = ((val < 0x8000) ? 0x8000 : val);
-            int newCount = count[address] - (val - last);
+            // Adjust the time remaining to the next flip-flop toggle so that the
+            // time already elapsed since the last toggle is preserved, i.e. the
+            // period write moves only the target, as on the real chip. If the
+            // elapsed time already exceeds the new period, the clamp below makes
+            // the overdue toggle happen straight away.
+            int newCount = count[address] + (val - last);
             count[address] = newCount < 1 ? 1 : newCount;
             break;
         }
@@ -351,7 +356,7 @@ public class GwtAYPSG implements AYPSG {
             val *= 2;
             int last = period[NOISE];
             period[NOISE] = val = val == 0 ? updateStep : val;
-            int newCount = count[NOISE] - (val - last);
+            int newCount = count[NOISE] + (val - last);
             count[NOISE] = newCount < 1 ? 1 : newCount;
             break;
         }
@@ -386,7 +391,7 @@ public class GwtAYPSG implements AYPSG {
             int val = (((registers[0x0C] << 8) | registers[0x0B]) * updateStep) << 1;
             int last = period[ENVELOPE];
             period[ENVELOPE] = val;
-            int newCount = count[ENVELOPE] - (val - last);
+            int newCount = count[ENVELOPE] + (val - last);
             count[ENVELOPE] = newCount < 1 ? 1 : newCount;
             break;
         }

--- a/html/src/main/java/emu/joric/gwt/GwtAYPSG.java
+++ b/html/src/main/java/emu/joric/gwt/GwtAYPSG.java
@@ -353,9 +353,14 @@ public class GwtAYPSG implements AYPSG {
         // Noise period.
         case 0x06: {
             int val = (value & 0x1f) * updateStep;
+            // A noise period of 0 behaves the same as a noise period of 1: the
+            // data sheet notes that the lowest period value is 1 for both tone
+            // and noise, and this behaviour has been verified using original
+            // Oric-1 hardware.
+            val = (val == 0 ? updateStep : val);
             val *= 2;
             int last = period[NOISE];
-            period[NOISE] = val = val == 0 ? updateStep : val;
+            period[NOISE] = val;
             int newCount = count[NOISE] + (val - last);
             count[NOISE] = newCount < 1 ? 1 : newCount;
             break;


### PR DESCRIPTION
**Note:** This PR is stacked on #15 (the period register writes fix) because the two touch adjacent lines in the noise period handler. I've based it on #15 rather than directly on master so that the two apply cleanly in the order I'd expect them to be merged (#15 first, then this), with no merge conflicts needing to be resolve. The trade-off is that this PR shows two commits - please review only the second ("Fix noise period 0 running at twice the speed of period 1"); the first is #15 and will drop out of this diff automatically once #15 is merged.

## Context

Fifth in the series of AY-3-8912 sound emulation improvements, web version first as before. The WIP deployment with the whole series applied is available here if you want to hear the overall impact: https://joric-wip.pages.dev

## Problem

A noise period of 0 plays noise that doesn't match the original Oric hardware - the noise generator runs at twice the rate it should. On the real chip a noise period of 0 behaves the same as a period of 1 (the data sheet notes that, as with the tone period, the lowest noise period value is 1).

To hear it: enable noise on channel A with `PLAY 0,1,0,0`, then compare `SOUND 4,0,15` (noise period 0) with `SOUND 4,1,15` (noise period 1). On the current web version period 0 is audibly different from period 1; on a real Oric-1 the two are identical.

The cause: the noise period handler maps a written value of 0 to "period 1", but it does so after the code has already doubled the period value, so 0 ends up mapped to half of period 1 - i.e. twice the rate.

## Fix

Apply the zero-to-one mapping before the doubling rather than after, so a noise period of 0 correctly behaves as period 1.

No equivalent change is needed in the tone period path: that handler clamps to a minimum period (one sample per half-cycle) as an anti-aliasing guard, which already covers a written value of 0.

## Scope

Web platform only - one file (GwtAYPSG), a small change to the noise period handler. No changes to core or the other platforms. Only a noise period of 0 is affected; all other noise periods are unchanged.

## Testing

Tested on macOS in Chrome. Confirmed `SOUND 4,0,15` and `SOUND 4,1,15` (after `PLAY 0,1,0,0`) now sound identical, instead of period 0 being noticeably different. I also verified this against a real Oric-1: on real hardware noise periods 0 and 1 are indistinguishable, while 1 and 2 are clearly different - matching the fixed behaviour.