### PR TITLE
Bring desktop dialogs to the foreground

### DIFF
--- a/lwjgl3/src/main/java/emu/joric/lwjgl3/DesktopDialogHandler.java
+++ b/lwjgl3/src/main/java/emu/joric/lwjgl3/DesktopDialogHandler.java
@@ -1,6 +1,7 @@
 package emu.joric.lwjgl3;
 
 import java.awt.Image;
+import java.awt.Window;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
@@ -15,6 +16,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
+import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -32,7 +34,50 @@ import emu.joric.ui.TextInputResponseHandler;
 public class DesktopDialogHandler implements DialogHandler {
 
     private boolean dialogOpen;
-    
+
+    // The Swing dialogs are shown on the AWT event dispatch thread (see the
+    // comment in confirm() for why), which is not the libGDX/GLFW main thread
+    // that owns the application window. On Windows the OS will then open a
+    // dialog *behind* the application window, because a thread that does not
+    // own the foreground window is not allowed to bring a new window to the
+    // front. To work around this each dialog is given a temporary owner window
+    // (see createDialogOwner) that is brought to the foreground.
+    //
+    // When true, that owner is made always-on-top, which reliably foregrounds
+    // the dialog but also keeps it pinned above every other window for as long
+    // as it is open. When false (the default), a gentler toFront()/requestFocus()
+    // is used instead, which does not pin the dialog above other applications
+    // (nicer if e.g. you want to switch away to check a filename) but may be
+    // less reliable at foregrounding on some platforms. Flip this to true if
+    // dialogs still appear behind the application window.
+    private static final boolean DIALOG_ALWAYS_ON_TOP = false;
+
+    /**
+     * Creates a temporary, effectively invisible owner window for a dialog and
+     * brings it to the foreground, so the dialog appears in front of the
+     * application rather than behind it (see DIALOG_ALWAYS_ON_TOP). The UTILITY
+     * window type keeps the owner out of the taskbar and the alt-tab list, and
+     * the 1x1 centred size keeps it out of sight while still centring the dialog
+     * on screen. The caller must dispose() the returned frame once the dialog
+     * has closed. Must be called on the AWT event dispatch thread.
+     *
+     * @return the temporary owner frame to pass as the dialog's parent.
+     */
+    private JFrame createDialogOwner() {
+        JFrame owner = new JFrame();
+        owner.setUndecorated(true);
+        owner.setType(Window.Type.UTILITY);
+        owner.setSize(1, 1);
+        owner.setLocationRelativeTo(null);
+        owner.setAlwaysOnTop(DIALOG_ALWAYS_ON_TOP);
+        owner.setVisible(true);
+        if (!DIALOG_ALWAYS_ON_TOP) {
+            owner.toFront();
+            owner.requestFocus();
+        }
+        return owner;
+    }
+
     private Icon importIcon;
     private Icon exportIcon;
     private Icon clearIcon;
@@ -117,7 +162,13 @@ public class DesktopDialogHandler implements DialogHandler {
             @Override
             public void run() {
                 dialogOpen = true;
-                final int output = JOptionPane.showConfirmDialog(null, message, "Please confirm", JOptionPane.YES_NO_OPTION);
+                JFrame owner = createDialogOwner();
+                final int output;
+                try {
+                    output = JOptionPane.showConfirmDialog(owner, message, "Please confirm", JOptionPane.YES_NO_OPTION);
+                } finally {
+                    owner.dispose();
+                }
                 dialogOpen = false;
                 Gdx.app.postRunnable(new Runnable() {
                     @Override
@@ -154,7 +205,13 @@ public class DesktopDialogHandler implements DialogHandler {
                 jfc.addChoosableFileFilter(filter);
 
                 dialogOpen = true;
-                final int returnValue = jfc.showOpenDialog(null);
+                JFrame owner = createDialogOwner();
+                final int returnValue;
+                try {
+                    returnValue = jfc.showOpenDialog(owner);
+                } finally {
+                    owner.dispose();
+                }
                 final String selectedPath = (returnValue == JFileChooser.APPROVE_OPTION)
                         ? jfc.getSelectedFile().getPath() : null;
                 dialogOpen = false;
@@ -182,8 +239,14 @@ public class DesktopDialogHandler implements DialogHandler {
             @Override
             public void run() {
                 dialogOpen = true;
-                final String text = (String) JOptionPane.showInputDialog(null, message, "Please enter value",
-                        JOptionPane.INFORMATION_MESSAGE, null, null, initialValue != null ? initialValue : "");
+                JFrame owner = createDialogOwner();
+                final String text;
+                try {
+                    text = (String) JOptionPane.showInputDialog(owner, message, "Please enter value",
+                            JOptionPane.INFORMATION_MESSAGE, null, null, initialValue != null ? initialValue : "");
+                } finally {
+                    owner.dispose();
+                }
                 dialogOpen = false;
                 Gdx.app.postRunnable(new Runnable() {
                     @Override
@@ -259,10 +322,15 @@ public class DesktopDialogHandler implements DialogHandler {
                 okButton.addMouseListener(mouseListener);
 
                 pane.setComponentOrientation(JOptionPane.getRootFrame().getComponentOrientation());
-                JDialog dialog = pane.createDialog("About JOric");
+                JFrame owner = createDialogOwner();
+                JDialog dialog = pane.createDialog(owner, "About JOric");
                 dialog.setIconImage(loadImage("png/joric-32x32.png"));
-                dialog.show();
-                dialog.dispose();
+                try {
+                    dialog.show();
+                } finally {
+                    dialog.dispose();
+                    owner.dispose();
+                }
 
                 final Object paneValue = pane.getValue();
                 dialogOpen = false;
@@ -290,8 +358,14 @@ public class DesktopDialogHandler implements DialogHandler {
             public void run() {
                 dialogOpen = true;
                 String dialogTitle = (title != null && !title.isEmpty()) ? title : "JOric";
-                final Object result = JOptionPane.showInputDialog(null, message, dialogTitle,
-                        JOptionPane.QUESTION_MESSAGE, null, options, currentSelection);
+                JFrame owner = createDialogOwner();
+                final Object result;
+                try {
+                    result = JOptionPane.showInputDialog(owner, message, dialogTitle,
+                            JOptionPane.QUESTION_MESSAGE, null, options, currentSelection);
+                } finally {
+                    owner.dispose();
+                }
                 dialogOpen = false;
                 Gdx.app.postRunnable(new Runnable() {
                     @Override


### PR DESCRIPTION

## Problem
Following the macOS dialog deadlock fix (#9), on (at least some versions of) Windows the Swing dialogs (file open, the settings/ROM chooser, the About box, and the quit/exit confirmations) can open behind the JOric main window instead of in front of it.

The cause is the macOS deadlock fix moved the Swing dialog calls onto the AWT event dispatch thread (EDT). On Windows, the OS only allows the thread that owns the current foreground window to bring a new window to the front. As the EDT does not own the GLFW main application window, so a dialog created by the EDT opens behind the main application window. Before the deadlock fix the dialogs ran on the main thread (which owns the GLFW window) and came to the front normally.

## Candidate Fix

For each dialog we now create a temporary, effectively invisible, owner window that is brought to the foreground, and disposed of as soon as the dialog is closed. The owner window is a 1x1, undecorated, UTILITY-type frame (the UTILITY type is meant to keep it out of the taskbar and the alt-tab list), created on the EDT inside the existing dispatch so the deadlock fix is preserved.

By default the code uses a gentle toFront()/requestFocus() to bring the dialog to the front without pinning it above other windows (so you can still switch away to, say, check a filename). A single DIALOG_ALWAYS_ON_TOP static flag switches the owner window to always-on-top for all the dialogs, which would foreground more reliably but keeps the dialog pinned above everything while it's open, even when switching away to other applications. Which mode should be set as the default behaviour will depend on the outcome of Windows testing. (See Testing section below.)

## Scope

Desktop (lwjgl3) only - one file (DesktopDialogHandler). No changes to core, web or Android. All the dialog methods route through a single shared owner-creating helper, so the behaviour and the toggle are uniform across them.

## Testing

Tested on macOS only. All the reachable dialogs open in front and dismiss correctly, with both the default gentle approach and the always-on-top toggle, and no visible stray window appears. (Note that the `promptForTextInput` appears to be unused currently, so is untested.)

I don't have a Windows machine, so I can't verify the actual fix there - that's the part that needs checking to see if the candidate fix works as is, or if it needs toggling to use the always-on-top mode.
- Do the dialogs now open in front of the application?
- If the gentle default foregrounding behaviour still opens them behind (I think Windows might ignore toFront() from a thread that doesn't own the foreground window - the same root cause), then flip DIALOG_ALWAYS_ON_TOP to true which should force the dialogs to the front.
- Does any stray 1x1 window appear in the taskbar or alt-tab while a dialog is open? (The UTILITY window type should prevent it, but I can't confirm that on Windows.)
- If the always-on-top mode is required, a judgment on whether that behaviour is ok or not, since always on-top windows have the potential to be irritating if you do need to switch to another application while they are displayed. I think it's probably ok on balance - but it's subjective.